### PR TITLE
Update cloud.md

### DIFF
--- a/content/en/docs/Neurodesktop/Getting started/cloud.md
+++ b/content/en/docs/Neurodesktop/Getting started/cloud.md
@@ -21,7 +21,7 @@ ssh -L 8080:127.0.0.1:8080 USER@IP
 Install Docker on the cloud instance from here: https://docs.docker.com/get-docker/. Additional information available here: https://neurodesk.github.io/docs/neurodesktop/getting-started/linux/#installing-docker 
 
 ### 3. Run Neurodesktop
-Create a local folder on the cloud instance to store persistent data (data that will not disappear if neurodesktop is stopped), e.g. ~/neurodesktop-storage
+Create a local folder ~/neurodesktop-storage on the cloud instance to store persistent data (data that will not disappear if neurodesktop is stopped)
 
 #### Option 1: NeuroDesktop.run
 Download and run the following executable


### PR DESCRIPTION
Removed the e.g. in point 3, as folder must be named ~/neurodesktop-storage for the subsequent instructions to work. For a quickstart, it's good enough