### PR TITLE
Update _index.md

### DIFF
--- a/content/en/applications/_index.md
+++ b/content/en/applications/_index.md
@@ -7,5 +7,5 @@ menu:
   main:
     weight: 10
 description: >
-  List of Applications. If any of the applications is not available under _Neurodesk_ --> _All applications_ in Neurodesk's start menu (notice that menu entries are sorted alphabetically), you might not be using the latest version of Neurodesktop. Please re-install Neurodesktop using the platform-specific instructions at https://neurodesk.github.io/docs/neurodesktop/getting-started/
+  List of Applications. If any of the applications is not available under _Neurodesk_ --> _All applications_ in Neurodesk's start menu (notice that menu entries are sorted alphabetically), you might not be using the latest version of Neurodesktop. Please use the platform-specific documentation page at https://neurodesk.github.io/docs/neurodesktop/getting-started/ to remove the current Neurodesktop ("Stopping neurodesktop" section down the page) and then re-install it ("Quickstart" section at the top of the page).
 ---


### PR DESCRIPTION
Clarified that to upgrade to latest version, users need to first remove the current neurodesktop and then re-install it. I also think that the title in the platform-specific doc pages should be "removing neurodesktop" rather than "stopping neurodesktop", as users need to understand that stuff in the home directory, for example, will be deleted. "stopping neurodesktop" sounds as if you can resume it later.