### PR TITLE
Update windows.md

### DIFF
--- a/content/en/docs/Neurodesktop/Getting started/windows.md
+++ b/content/en/docs/Neurodesktop/Getting started/windows.md
@@ -46,8 +46,13 @@ We do not recommend the use of the Firefox browser for accessing Neurodesktop, a
 - User is `user`
 - Password is `password`
 
-## Stopping neurodesktop:
+## Deleting neurodesktop:
 When done processing your data it is important to stop and remove the container - otherwise the next start or container update will give an error ("... The container name "/neurodesktop" is already in use...")
+
+{{< alert title="Note" >}}
+Notice that any data that were saved outside of /neurodesktop-storage would be lost. Please make sure to move all your data to that folder before deleting neurodesktop.
+{{< /alert >}}
+
 1. Click on the terminal from which you ran neurodesktop
 
 2. Press control-C


### PR DESCRIPTION
Better use "deleting" as we don't want people to think they are merely stopping the container.
I also added a warning clarifying all data outside /neurodesktop-storage would be lost