### PR TITLE
Update linux.md

### DIFF
--- a/content/en/docs/Neurodesktop/Getting started/linux.md
+++ b/content/en/docs/Neurodesktop/Getting started/linux.md
@@ -52,9 +52,14 @@ If using Firefox, you might not be able to paste clipboard content into the virt
 https://neurodesk.github.io/docs/neurodesktop/troubleshooting/#the-clipboard-in-firefox-is-not-working-correctly
 {{< /alert >}}
 
-4. neurodesktop is ready to use!
-- User is `user`
-- Password is `password`
+4. Press on "Desktop Auto-Resolution" under "ALL CONNECTIONS"
+
+5. If it is the first time you use Neruodesktop, wait until the desktop appears (it may take a few seconds). Otherwise, it should appear instantaneously.
+
+6. Neurodesk is ready to use! Click "What's next?" on the left of this page for further instructions.     
+
+7. For an optimal experience, switch your browser to full-screen mode by following the instructions for your browser here:
+https://www.thewindowsclub.com/open-chrome-edge-or-firefox-browser-in-full-screen-mode
 
 ## Deleting neurodesktop:
 When done processing your data it is important to stop and remove the container - otherwise the next start or container update will give an error ("... The container name "/neurodesktop" is already in use...")


### PR DESCRIPTION
Removed the mentioning of user and password as I do not see why users need to know them. It is just confusing (correct me if wrong).

I also added a few points: clicking on the Desktop Auto-Resolution option, waiting until Desktop appears, checking the "What's next?" section and switching browser to full-screen.

If you are happy with these changes, you're welcome to apply them to the rest of the installation pages (or request me to do it). Just notice that the full-screen thing is not relevant to Mac, where maximising the web browser makes it full-screen automatically. However, in Firefox on Mac that address and tab bars are still visible when in full-screen mode. I started to investigate how to remove them, but no solution yet.