### PR TITLE
Doc clarification

### DIFF
--- a/content/en/docs/Neurocommand/Getting started/linux.md
+++ b/content/en/docs/Neurocommand/Getting started/linux.md
@@ -27,8 +27,10 @@ description: >
 - Run `pip3 install -r neurodesk/requirements.txt --user` to install pre-requisite python packages
 - Run `bash build.sh --cli` to install in cli mode  
 - Run `bash containers.sh` for installing indiviual containers or `bash containers.sh --all` for installing all containers
-- Run `module use $PWD/local/containers/modules/` to add the containers to your module search path. Add this to your .bashrc if working.
+- Run `module use $PWD/local/containers/modules/` to add the containers to your module search path. Add this to your .bashrc if working. When adding to your .bashrc you will need to replace $PWD to point to the correct path, i.e. `module use ~/neurocommand/local/containers/modules/`.  
 - Run `ml avail` to see the installed containers at the top of the list (neurodesk containers will take preference over system modules with the same name). - If a container is not yet there run `ml --ignore_cache avail`
+- Every time you start a new shell you will need to run `conda activate neurocommand`. Unless you added it to your .bashrc, you will also need to run `module use PathToYourContainers`. 
+
 
 ### For Lxde desktops
 If running on an lxde desktop...
@@ -51,11 +53,12 @@ _Creates symlinks to menu files in installation dir_
 _Removes symlinks_  
 
 ## To update
-
 Run `git pull`  
-Run `bash build.sh`  
+Run `bash build.sh`  # this updates the neurocommand but not the modules
 _install.sh does not need to be run again_
-here are Mark's edits
+to update containers go into the neurodesktop directory and run `bash containers.sh` 
+Choose the module you want to update for example you want to update mrtrix3/3.0.2 module with the eddy_cuda fix:
+`~/neurocommand/local/fetch_containers.sh mrtrix3 3.0.2 20221108 mrview $@`
 
 ### To download all containers
 Run `bash containers.sh --all`

--- a/content/en/docs/Neurocommand/Getting started/linux.md
+++ b/content/en/docs/Neurocommand/Getting started/linux.md
@@ -55,6 +55,7 @@ _Removes symlinks_
 Run `git pull`  
 Run `bash build.sh`  
 _install.sh does not need to be run again_
+here are Mark's edits
 
 ### To download all containers
 Run `bash containers.sh --all`


### PR DESCRIPTION
Just did some clarifications for the neurocommand page, based on confusions I found, for example the old documentation did not say that one needs to run conda activate neurocommand for every new shell, or to cache the modules. And if you copy the $PWD into your .bashrc that's not gonna work - obviously why, but it was still confusing.

Also, what I am unclear about the update process,
I *think* the git pull and bash build.sh only update the conda neurocommand environment but not the containers?
So when you updated the mrtrix3/3.0.2 container to have the libs for cuda, our HPC neurocommand installation was still having the old containers. Interestingly bash containers.sh --all did NOT update the mrtrix3/3.0.2 module, probably because there already was mrtrix3/3.0.2 module, but bash containers.sh gives a specific list of downloadable containers including the date label. So calling that specific line then DOES update the container.


