### PR TITLE
Set default DNS server to 8.8.8.8 in Linux instructions.

### DIFF
--- a/content/en/docs/Getting Started/Neurodesktop/linux.md
+++ b/content/en/docs/Getting Started/Neurodesktop/linux.md
@@ -70,6 +70,7 @@ ssh -L 8888:127.0.0.1:8888 USER@IP
 docker volume create neurodesk-home &&
 sudo docker run \
   --shm-size=1gb -it --privileged --user=root --name neurodesktop \
+  --dns 8.8.8.8 \
   -v ~/neurodesktop-storage:/neurodesktop-storage \
   --mount source=neurodesk-home,target=/home/jovyan \
   -e NB_UID="$(id -u)" -e NB_GID="$(id -g)" \
@@ -96,6 +97,10 @@ If you get errors in neurodesktop then check if the ~/neurodesktop-storage direc
 ```bash
 chmod a+rwx ~/neurodesktop-storage
 ```
+{{< /alert >}}
+
+{{< alert color="warning">}}
+The Docker command uses the DNS server `8.8.8.8` (Google Public DNS). If that's not assessable on your network or causes problems then you can remove `--dns 8.8.8.8` from the command.
 {{< /alert >}}
 
 2. Once neurodesktop is downloaded, leave the terminal open and check which server neurodesktop is running on (Avoid pressing CTRL+C). 
@@ -216,6 +221,7 @@ sudo apt install nvidia-container-toolkit -y
 ```bash
 sudo docker run \
   --shm-size=1gb -it --privileged --user=root --name neurodesktop \
+  --dns 8.8.8.8 \
   -v ~/neurodesktop-storage:/neurodesktop-storage \
   -e NB_UID="$(id -u)" -e NB_GID="$(id -g)" \
   --gpus all \


### PR DESCRIPTION
NeuroDesktop was failing to startup. After looking into the root cause it turned out to be a DNS issue on my host. Docker was forwarding the incorrect DNS servers inside the container. Podman is unaffected by this since it seems to include it's own DNS server.

I'm proposing setting the default DNS server in the instructions to `8.8.8.8` (Google Public DNS). This should allow containers to start faster for those with DNS problems and will also fix DNS issues preventing containers from starting.

The case for making it a default is it won't break existing users unless their network blocks DNS and DNS problems come up in the container as CVMFS issues initially which are hard to diagnose.

@iishiishii This can also be added to the app startup too.

In the future we could change the startup script so it uses `dig` to make sure the sites are assessable first and automatically falls back to 8.8.8.8 if it detects problems with the host DNS configuration. This could cause subtle issues if the network is down and involves tuning timeouts (so the containers still start quickly) so we can start with the simple documentation change.