### PR TITLE
Linux install instructions: Fix Podman hyperlink

### DIFF
--- a/content/en/docs/Getting Started/Neurodesktop/linux.md
+++ b/content/en/docs/Getting Started/Neurodesktop/linux.md
@@ -15,7 +15,7 @@ description: >
 ## Quickstart
 ### 0. Install Docker or Podman
 Install Docker from here: https://docs.docker.com/get-docker/. Additional information is available [below](#installing-docker). 
-Alternatively, Neurodesk also works with Podman (https://podman.io/).
+Alternatively, Neurodesk also works with Podman (https://podman.io).
 
 To set up Neurodesk on Ubuntu, ensure both Podman client and server are installed. Follow the Podman installation instructions provided at https://podman.io/docs/installation for server setup. 
 


### PR DESCRIPTION
Podman link on website at https://www.neurodesk.org/docs/getting-started/neurodesktop/linux/ erroneously includes the close bracket character, resulting in a 404.