### PR TITLE
Fix: use github api to check links

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -12,10 +12,11 @@ aliveStatusCodes:
 replacementPatterns:
   - pattern: "^/"
     replacement: "https://neurodesk.org/"
+  - pattern: "^https://github.com/NeuroDesk/(.*?)/blob/main/(.*)"
+    replacement: "https://api.github.com/repos/NeuroDesk/$1/contents/$2"
 httpHeaders:
   - url:
-      - https://github.com
+      - https://api.github.com
     headers:
-      Authorization: ${{ secrets.GITHUB_TOKEN }}
-excludedFiles:
-- 'content/en/developers/contributors/_index.md'
+      Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}
+      Accept: application/vnd.github+json


### PR DESCRIPTION
Replace github.com with api.github.com and its api path