### PR TITLE
Add PR preview workflow (ci): preview per-PR on gh-pages/pr-N

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,180 @@
+name: PR Preview Deploy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-22.04
+    env:
+      HUGO_VERSION: 0.146.0
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests
+
+      - name: Install Node dependencies
+        run: npm install
+
+      - name: Write applist.json
+        env:
+          ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}
+        run: |
+          if [ -n "$ZENODO_TOKEN" ]; then
+            python .github/workflows/write-app-json.py --zenodo_token "$ZENODO_TOKEN"
+          else
+            echo "ZENODO_TOKEN not set, skipping applist generation"
+          fi
+
+      - name: Build preview
+        env:
+          HUGO_ENVIRONMENT: preview
+          HUGO_ENV: preview
+        run: |
+          PREVIEW_PATH="pr-${{ github.event.pull_request.number }}"
+          
+          # Use the target repo's domain (where PR is being merged to)
+          if [[ "${{ github.event.pull_request.base.repo.full_name }}" == "neurodesk/neurodesk.github.io" ]]; then
+            BASE_URL="https://neurodesk.org/${PREVIEW_PATH}/"
+            echo "Building PR preview for production: ${BASE_URL}"
+          else
+            # For PRs to forks (rare case)
+            BASE_URL="https://${{ github.event.pull_request.base.repo.owner.login }}.github.io/${{ github.event.pull_request.base.repo.name }}/${PREVIEW_PATH}/"
+            echo "Building PR preview for fork: ${BASE_URL}"
+          fi
+          
+          hugo --minify --baseURL "${BASE_URL}"
+          
+          mkdir -p preview-deploy/${PREVIEW_PATH}
+          cp -r public/* preview-deploy/${PREVIEW_PATH}/
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./preview-deploy
+          destination_dir: .
+          keep_files: true
+
+      - name: Comment preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            // Use the target repo (base) where PR is being merged to
+            const baseRepo = context.payload.pull_request.base.repo;
+
+            let previewUrl;
+            if (baseRepo.owner.login === 'neurodesk' && baseRepo.name === 'neurodesk.github.io') {
+              previewUrl = `https://neurodesk.org/pr-${prNumber}/`;
+            } else {
+              previewUrl = `https://${baseRepo.owner.login}.github.io/${baseRepo.name}/pr-${prNumber}/`;
+            }
+
+            const marker = '<!-- pr-preview:neurodesk -->';
+            const commentBody = `${marker}\n## Preview Deployed\n\n**Preview URL:** ${previewUrl}\n\nThis preview updates automatically when you push new commits to this PR.\nIt will be cleaned up when the PR is closed or merged.\n\n<details>\n<summary>Build Details</summary>\n\n- Commit: ${context.payload.pull_request.head.sha.substring(0, 7)}\n- Branch: \`${context.payload.pull_request.head.ref}\`\n- Hugo Version: ${process.env.HUGO_VERSION}\n\n</details>`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100
+            });
+
+            const botComment = comments.find(comment => comment.body && comment.body.includes(marker));
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: commentBody
+              });
+              console.log('Updated existing preview comment');
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: commentBody
+              });
+              console.log('Created new preview comment');
+            }
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          fetch-depth: 0
+
+      - name: Remove preview directory
+        run: |
+          PREVIEW_PATH="pr-${{ github.event.pull_request.number }}"
+
+          # Ensure we have latest gh-pages to avoid push conflicts
+          git fetch origin gh-pages
+          git checkout gh-pages
+          git pull --rebase origin gh-pages || true
+
+          if [ -d "$PREVIEW_PATH" ]; then
+            echo "Removing preview directory: $PREVIEW_PATH"
+            git rm -rf "$PREVIEW_PATH" || true
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            if git diff --staged --quiet; then
+              echo "Nothing to commit after removal (nothing staged)"
+            else
+              git commit -m "cleanup: remove preview for PR #${{ github.event.pull_request.number }}" || true
+              git push origin gh-pages || true
+              echo "Preview cleaned up successfully"
+            fi
+          else
+            echo "Preview directory not found, may have been already cleaned up"
+          fi
+
+      - name: Comment cleanup
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: 'Preview cleaned up after PR closure.'
+            });


### PR DESCRIPTION
**What it does**

1. On pull_request (opened, synchronize, reopened):
2. Builds the site with Hugo using baseURL = /pr-<PR_NUMBER>/ for previews.
3. Deploys the generated site to gh-pages/pr-<PR_NUMBER>/ on the upstream repository.
- If base repo == neurodesk/neurodesk.github.io -> previewUrl = https://neurodesk.org/pr-<N>/
- Else -> previewUrl = https://{base.owner}.github.io/{base.repo}/pr-<N>/
4. Posts (or updates) a single PR comment with the preview URL (marker: <!-- pr-preview:neurodesk -->).
5. On pull_request closed: Removes gh-pages/pr-<PR_NUMBER>/ and posts a cleanup comment.

**Why**

- Provides reviewers a live preview of changes before merge.
- Keeps previews isolated under per‑PR subfolders to avoid interfering with the production site.
- Testing / acceptance criteria

**After this workflow is merged to upstream:**

1. Opening a PR from a fork should trigger the upstream PR preview build.
2. A preview URL (https://neurodesk.org/pr-<N>/) is posted on the PR (single, updated comment).
3. The preview shows the PR changes rendered. (If images/CSS are broken, that’s likely due to absolute /static/ references. Later on we'll work with converting these to Hugo helpers.)

**Merging the PR:**

1. Triggers the production build (push to main triggers the production workflow) and updates production.
2. Triggers the preview cleanup (preview folder removed from gh-pages).

**Closing a PR without merging:**

1. The preview folder is removed and a cleanup comment is posted.