### PR TITLE
Add secure PR preview workflows (build/deploy/cleanup) with artifact lifecycle management

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -93,4 +93,5 @@ jobs:
           path: |
             preview-deploy/
             pr-metadata/
-          retention-days: 1
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   issues: write
+  actions: write
 
 jobs:
   cleanup:
@@ -54,3 +55,50 @@ jobs:
               issue_number: prNumber,
               body: 'Preview cleaned up after PR closure.'
             });
+
+      - name: Delete preview artifacts
+        uses: actions/github-script@v7
+        continue-on-error: true
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const artifactName = `pr-preview-${prNumber}`;
+            
+            console.log(`Searching for artifacts named: ${artifactName}`);
+            
+            // List all artifacts for the repo (paginate if needed)
+            let page = 1;
+            let deletedCount = 0;
+            
+            while (page <= 5) {  // Safety limit: check first 5 pages (500 artifacts max)
+              const { data } = await github.rest.actions.listArtifactsForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+                page: page
+              });
+              
+              if (!data.artifacts || data.artifacts.length === 0) {
+                break;
+              }
+              
+              for (const artifact of data.artifacts) {
+                if (artifact.name === artifactName) {
+                  try {
+                    await github.rest.actions.deleteArtifact({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      artifact_id: artifact.id
+                    });
+                    console.log(`✓ Deleted artifact: ${artifact.name} (ID: ${artifact.id})`);
+                    deletedCount++;
+                  } catch (error) {
+                    console.log(`✗ Failed to delete artifact ${artifact.id}: ${error.message}`);
+                  }
+                }
+              }
+              
+              page++;
+            }
+            
+            console.log(`Cleanup complete. Deleted ${deletedCount} artifact(s).`);

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -25,6 +25,7 @@ jobs:
           name: pr-preview-${{ github.event.workflow_run.pull_requests[0].number }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
+        continue-on-error: false
 
       - name: Read PR metadata
         id: pr-meta


### PR DESCRIPTION
Adds a secure, fork-safe PR preview system composed of three GitHub Actions workflows:

- `pr-build.yml` — builds the Hugo preview for every pull request (runs in the PR/fork context, no secrets exposed) and uploads a `pr-preview-<N>` artifact.
- `pr-deploy.yml` — triggered by a successful `pr-build` workflow_run; runs in the base repo context and deploys the uploaded artifact to `gh-pages` under `pr-<N>/`, then posts or updates a PR comment with the preview URL.
- `pr-cleanup.yml` — runs when a PR is closed or merged; removes the `pr-<N>/` directory from `gh-pages` and deletes the uploaded artifact(s) via the GitHub Actions API.

Motivation
Previously a single workflow attempted to build and push preview artifacts from the PR context, which fails for forked PRs (403) because GitHub limits secrets and write permission for workflows triggered from forks. This change implements the recommended secure pattern: untrusted builds in the PR context only, then deploys in the trusted base repo context.

What changed
- New workflows added: `pr-build.yml`, `pr-deploy.yml`, `pr-cleanup.yml`.
- Artifact retention extended to 7 days (prevents premature expiry before deploy).
- `pr-cleanup.yml` actively deletes `pr-preview-<N>` artifacts on PR close (paginated search + deletion).
- Fail-fast behavior on missing files/artifacts (`if-no-files-found: error`, explicit download checks).

Files of interest
- ` .github/workflows/pr-build.yml` — build and upload artifact (PR context)
- ` .github/workflows/pr-deploy.yml` — download and deploy artifact to `gh-pages` (base context)
- ` .github/workflows/pr-cleanup.yml` — remove preview and delete artifacts when PR closes

How it works (short)
1. Contributor opens PR → `pr-build.yml` runs in PR/fork context and uploads `pr-preview-<PR>` artifact.
2. When build completes successfully, `pr-deploy.yml` runs in the base repo and downloads the artifact by run-id, deploys to `gh-pages` under `pr-<N>/`, and posts/updates a PR comment with the preview URL.
3. When the PR is closed or merged, `pr-cleanup.yml` removes `pr-<N>/` from `gh-pages` and deletes the artifact via the Actions API.