### PR TITLE
Whitelist 403 errors  on linkchecker

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -9,6 +9,7 @@ aliveStatusCodes:
   - 200
   - 201
   - 204
+  - 403
 replacementPatterns:
   - pattern: "^/"
     replacement: "https://neurodesk.org/"


### PR DESCRIPTION
Cloudflare and sites seem to be blocking automated tools.

Whitelisting the 403 errors to rescope the linkchecking, just check if the links themselves exist and are valid.