### PR TITLE
Change ants module load to version 2.6.0

### DIFF
--- a/content/en/Getting-Started/Installations/sherlock.md
+++ b/content/en/Getting-Started/Installations/sherlock.md
@@ -68,7 +68,7 @@ put this in a file, e.g. `submit.sbatch`:
 
 module purge
 module use $GROUP_HOME/modules/
-module load ants
+module load ants/2.6.0
 ants.... $1
 ```
 


### PR DESCRIPTION
Updated ants module version to 2.6.0 in the installation instructions.

<!-- You may delete this guidance once you've edited the PR description. -->

## Preview guidance (please read)

It may take a few minutes after the build succeeds for the PR preview to become live. If you see a 404, wait a couple minutes and refresh.

## About the bot comment

- The bot comment will contain the preview URL and a short checklist you can complete (it will not modify your PR body). Please react 👍 to the bot comment when you are ready for a reviewer to look at your changes.

## Contact / help

If you need help or access, contact one of the code owners: @neurodesk/website-team 

Thank you — this helps reviewers know your PR is ready and reduces churn during review.
