### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/on-opening-issue.yml
+++ b/.github/workflows/on-opening-issue.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   add-issue-to-project:
     uses: neurodesk/neurodesk.github.io/.github/workflows/add-issue-to-project.yml@main


### PR DESCRIPTION
Potential fix for [https://github.com/neurodesk/neurodesk.github.io/security/code-scanning/5](https://github.com/neurodesk/neurodesk.github.io/security/code-scanning/5)

Add an explicit `permissions` block to `.github/workflows/on-opening-issue.yml` at the workflow root (preferred here since there is one job and it uses a reusable workflow). This ensures `GITHUB_TOKEN` is restricted regardless of repository/org defaults and documents intended access.

For this workflow, a safe minimal baseline is:

- `contents: read`

This generally preserves ability to read repository metadata while avoiding broad write scopes. If the called reusable workflow later requires additional scopes, those can be added explicitly (for example `issues: write`), but do not grant them unless needed.

Change location: insert `permissions:` between the `on:` trigger block and `jobs:` block in `.github/workflows/on-opening-issue.yml`.

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
