### PR TITLE
fix(ci): eliminate pr-cleanup vs pr-deploy artifact race

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -9,6 +9,16 @@ permissions:
   issues: write
   actions: write
 
+# Best-effort: share the build's concurrency group (set in pr-build.yml) so
+# closing a PR cancels any in-flight preview build. This is timing-dependent
+# — cleanup must reach the concurrency-evaluation stage before the build
+# finishes uploading its artifact. The actual safety net is the
+# "Check PR state" step in pr-deploy.yml, which skips deploy steps when the
+# PR has already closed.
+concurrency:
+  group: preview-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   cleanup:
     runs-on: ubuntu-22.04
@@ -81,49 +91,10 @@ jobs:
               core.info(`Skipping cleanup comment (likely permissions on forked PRs): ${error.message}`);
             }
 
-      - name: Delete preview artifacts
-        uses: actions/github-script@v7
-        continue-on-error: true
-        with:
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const artifactName = `pr-preview-${prNumber}`;
-            
-            console.log(`Searching for artifacts named: ${artifactName}`);
-            
-            // List all artifacts for the repo (paginate if needed)
-            let page = 1;
-            let deletedCount = 0;
-            
-            while (page <= 5) {  // Safety limit: check first 5 pages (500 artifacts max)
-              const { data } = await github.rest.actions.listArtifactsForRepo({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                per_page: 100,
-                page: page
-              });
-              
-              if (!data.artifacts || data.artifacts.length === 0) {
-                break;
-              }
-              
-              for (const artifact of data.artifacts) {
-                if (artifact.name === artifactName) {
-                  try {
-                    await github.rest.actions.deleteArtifact({
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      artifact_id: artifact.id
-                    });
-                    console.log(`✓ Deleted artifact: ${artifact.name} (ID: ${artifact.id})`);
-                    deletedCount++;
-                  } catch (error) {
-                    console.log(`✗ Failed to delete artifact ${artifact.id}: ${error.message}`);
-                  }
-                }
-              }
-              
-              page++;
-            }
-            
-            console.log(`Cleanup complete. Deleted ${deletedCount} artifact(s).`);
+      # Note: artifacts are NOT deleted here. They expire automatically via
+      # `retention-days: 7` set in pr-build.yml. Synchronous deletion on PR
+      # close raced with in-flight builds (see run 26075660775): cleanup could
+      # delete an artifact one second after the build uploaded it but before
+      # pr-deploy.yml could read it. Letting retention handle expiration
+      # removes the race entirely. Concurrency-group cancellation (above)
+      # prevents the build from finishing in the common case anyway.

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -169,8 +169,44 @@ jobs:
           
           echo "All metadata validated successfully"
 
+      - name: Check PR state
+        # Defense-in-depth: if the PR has already closed between build and
+        # deploy (e.g. cleanup workflow could not cancel the build in time),
+        # skip the gh-pages push and PR comment so we don't re-create a
+        # preview directory for a merged PR. Uses the validated PR number,
+        # NOT workflow_run.display_title (which is the commit subject and
+        # would not contain the PR number).
+        id: check-pr-state
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr-meta.outputs.pr-number }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            // On API error (404, rate-limit, transient): default to proceed
+            // so a transient hiccup never blocks a legitimate deploy. This
+            // step is purely additive defense.
+            try {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              if (pr.state === 'closed') {
+                const reason = pr.merged ? 'merged' : 'closed';
+                core.notice(`PR #${prNumber} already ${reason} — skipping preview deploy steps`);
+                core.setOutput('skip', 'true');
+              } else {
+                core.info(`PR #${prNumber} is open — proceeding with deploy`);
+                core.setOutput('skip', 'false');
+              }
+            } catch (error) {
+              core.warning(`Could not fetch PR #${prNumber} state (${error.message}); proceeding with deploy`);
+              core.setOutput('skip', 'false');
+            }
+
       - name: Remove legacy CNAME on gh-pages (target branch)
-        if: ${{ steps.pr-meta.outputs.base-repo == 'neurodesk/neurodesk.github.io' }}
+        if: ${{ steps.pr-meta.outputs.base-repo == 'neurodesk/neurodesk.github.io' && steps.check-pr-state.outputs.skip != 'true' }}
         env:
           PR_NUMBER: ${{ steps.pr-meta.outputs.pr-number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -199,6 +235,7 @@ jobs:
           fi
 
       - name: Deploy to gh-pages
+        if: ${{ steps.check-pr-state.outputs.skip != 'true' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -207,7 +244,7 @@ jobs:
           keep_files: true
 
       - name: Trigger Pages deploy to include previews
-        if: ${{ steps.pr-meta.outputs.base-repo == 'neurodesk/neurodesk.github.io' }}
+        if: ${{ steps.pr-meta.outputs.base-repo == 'neurodesk/neurodesk.github.io' && steps.check-pr-state.outputs.skip != 'true' }}
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ steps.pr-meta.outputs.pr-number }}
@@ -237,6 +274,7 @@ jobs:
             core.info('Triggered repository_dispatch: pr-preview-updated');
 
       - name: Comment preview URL
+        if: ${{ steps.check-pr-state.outputs.skip != 'true' }}
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ steps.pr-meta.outputs.pr-number }}


### PR DESCRIPTION
## Summary

Fixes the race that broke [run 26075660775](https://github.com/neurodesk/neurodesk.github.io/actions/runs/26075660775) of PR Preview Deploy — failed for PR #750 with \`No PR preview artifact found\`.

### Timeline of the race

\`\`\`
04:09:51Z  PR #750 merged
04:10:20Z  pr-build finalizes artifact pr-preview-750
04:10:21Z  pr-cleanup (triggered by merge close) deletes that artifact (1s race)
04:10:24Z  pr-build completes, fires workflow_run
04:10:32Z  pr-deploy starts, finds no artifact, throws
\`\`\`

Triggered the race because the cleanup workflow synchronously deleted the build artifact one second after the build uploaded it but before the deploy workflow could read it.

### Three changes

1. **\`pr-cleanup.yml\`** — adopt \`pr-build.yml\`'s concurrency group (\`preview-build-<N>\`, \`cancel-in-progress: true\`) so closing a PR cancels the in-flight build before it finishes. *Best-effort* — timing-dependent.
2. **\`pr-cleanup.yml\`** — remove the synchronous "Delete preview artifacts" step. Artifacts already expire via \`retention-days: 7\` set in \`pr-build.yml\`. **This removes the race at its source.**
3. **\`pr-deploy.yml\`** — new \"Check PR state\" step queries \`pulls.get\` on the validated PR number; if \`state==closed\`, sets \`skip=true\`. Subsequent steps (remove-CNAME, deploy-to-gh-pages, trigger-Pages, comment-URL) are gated on \`skip != 'true'\`. Wrapped in try/catch so transient API errors default to \"proceed\".

### Defense layers, in order

- **Layer 1 (Fix #1)** — cancel the build before it finishes. Cancelled \`workflow_run\` doesn't trigger deploy at all. Best-effort.
- **Layer 2 (Fix #2)** — even if deploy fires, the artifact still exists; no race with cleanup.
- **Layer 3 (Fix #3)** — even if everything else is in flight, deploy notices the PR is closed and skips the gh-pages push / PR comment.

### Trade-offs

- Artifact retention now governed entirely by \`retention-days: 7\` (was: synchronous delete on close). Storage cost: ~85 MB per recent build × ≤7 days. Trivial.
- Reopen-then-close edge case: with \`cancel-in-progress: true\` on cleanup, a second cleanup will cancel the first. Cleanup is idempotent (\`git rm\` + \`git push\` with \`|| true\`), so this is acceptable.

## Test plan

- [ ] Open a fresh PR; confirm preview comment posts with correct URL.
- [ ] Open a PR, push twice; confirm preview-build runs are cancelled correctly by their own concurrency group (unchanged behavior).
- [ ] Open a PR; close it without merge; confirm \`gh-pages/pr-<N>/\` removed and no deploy fires.
- [ ] Open a PR; merge it; confirm:
  - In-flight build (if any) is cancelled by cleanup's concurrency group, OR
  - If build completed, deploy's PR-state check skips with the notice \`PR #N already merged — skipping preview deploy steps\` and does NOT push to gh-pages.
- [ ] Confirm the build's artifact is still present in the Actions UI for 7 days post-merge (not synchronously deleted).

## Related

- Failed run: https://github.com/neurodesk/neurodesk.github.io/actions/runs/26075660775
- Original three-workflow split (context): commit 7aff7a29