### PR TITLE
[codex] Pin Node 24 for Hugo builds

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -43,7 +43,12 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Install dependencies
+      - name: Set up Node.js for Hugo
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
           pip install requests
@@ -52,7 +57,7 @@ jobs:
         id: pages
         uses: actions/configure-pages@v6
 
-      - name: Install dependencies
+      - name: Install Node dependencies
         run: | 
           npm install
 

--- a/.github/workflows/hugo-docsy-upgrade-check.yml
+++ b/.github/workflows/hugo-docsy-upgrade-check.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install Node dependencies

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -36,6 +36,11 @@ jobs:
         with:
           python-version: '3.10'
 
+      - name: Set up Node.js for Hugo
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- Pin Node 24 before Hugo/PostCSS builds in the Pages and PR preview workflows.
- Keep the Docsy compatibility workflow aligned with Hugo 0.161.x by running its npm/PostCSS step on Node 24.

## Root cause
Hugo 0.161.x runs PostCSS through Node with the `--permission` flag. The Pages build was using the Ubuntu 22.04 runner default Node 20, which fails with `bad option: --permission`.

## Validation
- `git diff --check`
- `actionlint .github/workflows/gh-pages.yml .github/workflows/pr-build.yml`
- `actionlint -shellcheck= .github/workflows/gh-pages.yml .github/workflows/pr-build.yml .github/workflows/hugo-docsy-upgrade-check.yml`
- Dockerized Hugo 0.161.1 build with Node 24 completed successfully.
