### PR TITLE
[codex] Check staging links in Pages CI

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -13,4 +13,4 @@ aliveStatusCodes:
   - 403
 replacementPatterns:
   - pattern: "^/"
-    replacement: "https://neurodesk.org/"
+    replacement: "https://neurodesk.github.io/"


### PR DESCRIPTION
## Summary
- Point Linkspector root-relative URL replacement at the staging Pages domain.

## Root cause
The staging Pages workflow builds and deploys `https://neurodesk.github.io/`, but Linkspector rewrote root-relative links to `https://neurodesk.org/`. Newly deployed staging assets can fail link checking until they are promoted to production.

## Validation
- `npx -y @umbrelladocs/linkspector@0.5.2 check -c .linkspector.yml -s`
- `git diff --check`
