### PR TITLE
fix puppeteer cache for link checker

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -209,10 +209,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUPPETEER_CACHE_DIR: ${{ runner.temp }}/puppeteer-cache
         run: |
           set -euo pipefail
 
           echo '::group::Installing linkspector'
+          rm -rf "$PUPPETEER_CACHE_DIR"
+          mkdir -p "$PUPPETEER_CACHE_DIR"
           npm install -g @umbrelladocs/linkspector@0.5.2 puppeteer@^24.37.5
           puppeteer browsers install chrome
           linkspector --version


### PR DESCRIPTION
## Summary
- Use a per-job Puppeteer cache for the Linkspector job
- Clear and recreate that cache before installing Chrome

## Why
The GitHub-hosted runner had a stale/incomplete Puppeteer Chrome cache, which made `puppeteer browsers install chrome` fail before Linkspector could crawl the site.

## Validation
- `git diff --check`
- YAML parse with Ruby
- shell smoke check for the cache setup