### PR TITLE
use system Chrome for Linkspector

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -209,15 +209,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PUPPETEER_CACHE_DIR: ${{ runner.temp }}/puppeteer-cache
+          PUPPETEER_SKIP_DOWNLOAD: "true"
         run: |
           set -euo pipefail
 
           echo '::group::Installing linkspector'
-          rm -rf "$PUPPETEER_CACHE_DIR"
-          mkdir -p "$PUPPETEER_CACHE_DIR"
-          npm install -g @umbrelladocs/linkspector@0.5.2 puppeteer@^24.37.5
-          puppeteer browsers install chrome
+          CHROME_BIN="$(command -v google-chrome || command -v google-chrome-stable || command -v chromium-browser || command -v chromium || true)"
+          if [ -z "$CHROME_BIN" ]; then
+            echo "No system Chrome or Chromium executable found" >&2
+            exit 1
+          fi
+          export PUPPETEER_EXECUTABLE_PATH="$CHROME_BIN"
+          echo "Using Chrome at $PUPPETEER_EXECUTABLE_PATH"
+          npm install -g @umbrelladocs/linkspector@0.5.2
           linkspector --version
           echo '::endgroup::'
 


### PR DESCRIPTION
## Summary
- Stop downloading Puppeteer's pinned Chrome build in the link-check job
- Use the Chrome/Chromium already installed on the Ubuntu 24.04 runner via `PUPPETEER_EXECUTABLE_PATH`
- Keep Puppeteer package downloads disabled with `PUPPETEER_SKIP_DOWNLOAD`

## Why
The merged cache fix proved the cache path was no longer stale, but Puppeteer still created an incomplete pinned Chrome install for `148.0.7778.97`. Linkspector documents `PUPPETEER_EXECUTABLE_PATH` as the supported way to use system Chrome.

## Validation
- `git diff --check`
- YAML parse with Ruby
- Confirmed the GitHub Ubuntu 24.04 runner image includes Google Chrome and Chromium