### PR TITLE
[codex] Ignore flaky National Academies DOI link check

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -7,6 +7,7 @@ ignorePatterns:
   - pattern: '^https://www\.humanbrainmapping\.org/i4a/pages/index\.cfm\?pageid=3912$'
   - pattern: '^https://www\.humanconnectome\.org/software/get-connectome-workbench#download$'
   - pattern: '^https://doi\.org/10\.1017/S0007114525000406$'
+  - pattern: '^https://doi\.org/10\.17226/25303$'
 useGitIgnore: true
 aliveStatusCodes:
   - 200


### PR DESCRIPTION
## Summary
- Ignore the exact National Academies DOI URL that returned 503 to Linkspector in the Pages workflow.
- Keep the source citation unchanged while preserving link checks for the rest of the site.

## Root cause
The GitHub Pages check-links run reached Linkspector successfully, but one valid external DOI URL returned HTTP 503 to the automated crawler. A direct curl probe resolved the DOI through National Academies to HTTP 200.

## Validation
- git diff --check
- env PUPPETEER_SKIP_DOWNLOAD=true PUPPETEER_EXECUTABLE_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' npx --yes @umbrelladocs/linkspector@0.5.2 check -c .linkspector.yml -s