### PR TITLE
[codex] Fix Linkspector external timeouts

### DIFF
--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -6,8 +6,13 @@ ignorePatterns:
   - pattern: '^https://www.biorxiv.org/content/'
   - pattern: '^https://www\.humanbrainmapping\.org/i4a/pages/index\.cfm\?pageid=3912$'
   - pattern: '^https://www\.humanconnectome\.org/software/get-connectome-workbench#download$'
-  - pattern: '^https://doi\.org/10\.1017/S0007114525000406$'
-  - pattern: '^https://doi\.org/10\.17226/25303$'
+  - pattern: '^https://rdcu\.be/eqro7$'
+  - pattern: '^https://www\.contributor-covenant\.org/?$'
+  - pattern: '^https://www\.contributor-covenant\.org/version/2/0/code_of_conduct(?:\.html|/)?$'
+  - pattern: '^https://www\.contributor-covenant\.org/faq/?$'
+  - pattern: '^https://www\.contributor-covenant\.org/translations/?$'
+  - pattern: '^https://docs\.sylabs\.io/guides/3\.5/user-guide/quick_start\.html$'
+  - pattern: '^https://workgroup\.stanford\.edu/ords/regapps/r/wgadmin/inbound\?clear=702&p702_wg_id=oak:GROUPNAME$'
 useGitIgnore: true
 aliveStatusCodes:
   - 200
@@ -15,5 +20,7 @@ aliveStatusCodes:
   - 204
   - 403
 replacementPatterns:
+  - pattern: '^https://doi\.org/(.+)$'
+    replacement: 'https://doi.org/api/handles/$1'
   - pattern: "^/"
     replacement: "https://neurodesk.github.io/"


### PR DESCRIPTION
## Summary
- validate DOI links through the DOI handle API instead of loading publisher landing pages
- exact-ignore external pages that are valid for humans but unreliable for unauthenticated/headless link checks

## Root cause
The scheduled Pages workflow reached content validation successfully, but Linkspector timed out in headless Chrome on several third-party pages. Independent HEAD checks showed the DOI links resolve, while the Stanford workgroup template URL redirects into SSO.

## Validation
- `PUPPETEER_SKIP_DOWNLOAD=true PUPPETEER_EXECUTABLE_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" npx -y @umbrelladocs/linkspector@0.5.2 check -c .linkspector.yml -s`
- `git diff --check`